### PR TITLE
Laravel update broke getDefaultDriver

### DIFF
--- a/src/Imagine/ImagineManager.php
+++ b/src/Imagine/ImagineManager.php
@@ -39,7 +39,7 @@ class ImagineManager extends Manager
      *
      * @return string
      */
-    protected function getDefaultDriver()
+    public function getDefaultDriver()
     {
         return $this->app['config']->get('orchestra/imagine::driver', 'gd');
     }


### PR DESCRIPTION
https://github.com/laravel/framework/commit/8b523557560765d19e67e190c7272c6634f3fdc4#diff-e10df0cf984701aece6ffd81877713a1

This laravel update requires getDefaultDriver to be declared public
